### PR TITLE
Downgrade BlockChypTest TargetFramework to netcoreapp2.0

### DIFF
--- a/tests/BlockChypTest/BlockChypTest.csproj
+++ b/tests/BlockChypTest/BlockChypTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <PackageId>BlockChypTest</PackageId>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/tests/BlockChypTest/IntegrationTestConfiguration.cs
+++ b/tests/BlockChypTest/IntegrationTestConfiguration.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text.Json;
+using Newtonsoft.Json;
 using BlockChyp;
 using BlockChyp.Client;
 
@@ -11,15 +11,15 @@ namespace BlockChypTest
     {
         private IntegrationTestConfiguration()
         {
-            var configFilePath = ConfigFilePath();
+            string configFilePath = ConfigFilePath();
             if (!File.Exists(configFilePath))
             {
                 throw new FileNotFoundException($"No integration test config file: {configFilePath}", configFilePath);
             }
 
-            var data = File.ReadAllText(configFilePath);
+            string data = File.ReadAllText(configFilePath);
 
-            Settings = JsonSerializer.Deserialize<IntegrationTestSettings>(data);
+            Settings = JsonConvert.DeserializeObject<IntegrationTestSettings>(data);
         }
 
         public IntegrationTestSettings Settings { get; }

--- a/tests/BlockChypTest/IntegrationTestSettings.cs
+++ b/tests/BlockChypTest/IntegrationTestSettings.cs
@@ -1,28 +1,28 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BlockChypTest
 {
     public class IntegrationTestSettings
     {
-        [JsonPropertyName("gatewayHost")]
+        [JsonProperty("gatewayHost")]
         public string GatewayUrl { get; set; }
 
-        [JsonPropertyName("testGatewayHost")]
+        [JsonProperty("testGatewayHost")]
         public string GatewayTestUrl { get; set; }
 
-        [JsonPropertyName("defaultTerminalName")]
+        [JsonProperty("defaultTerminalName")]
         public string DefaultTerminalName { get; set; }
 
-        [JsonPropertyName("defaultTerminalAddress")]
+        [JsonProperty("defaultTerminalAddress")]
         public string DefaultTerminalAddress { get; set; }
 
-        [JsonPropertyName("apiKey")]
+        [JsonProperty("apiKey")]
         public string ApiKey { get; set; }
 
-        [JsonPropertyName("bearerToken")]
+        [JsonProperty("bearerToken")]
         public string BearerToken { get; set; }
 
-        [JsonPropertyName("signingKey")]
+        [JsonProperty("signingKey")]
         public string SigningKey { get; set; }
     }
 }


### PR DESCRIPTION
.NET Core 3.0 is set to release a bit later this year and, currently,
only "preview" releases are available. I think we should stick with a
`TargetFramework` of `netcoreapp2.0` for the time being as this also
corresponds with `netstandard2.0`.

https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support

Thoughts?