### PR TITLE
Refactor a few methods in Crypto and add property-based tests

### DIFF
--- a/src/BlockChyp/Client/Crypto.cs
+++ b/src/BlockChyp/Client/Crypto.cs
@@ -95,14 +95,18 @@ namespace BlockChyp.Client
         /// <param name="input">The hexadecimal string to convert.</param>
         public static byte[] FromHex(string input)
         {
-            var ln = input.Length / 2;
-            var result = new byte[ln];
-
-            for (int i = 0; i < ln; i++)
+            if (input.Length % 2 != 0)
+            {
+                throw new ArgumentException(
+                    String.Format("The hex string cannot have an odd number of characters: {0}", input),
+                    nameof(input)
+                );
+            }
+            byte[] result = new byte[input.Length / 2];
+            for (int i = 0; i < result.Length; i++)
             {
                 result[i] = Convert.ToByte(input.Substring(i * 2, 2), 16);
             }
-
             return result;
         }
 

--- a/src/BlockChyp/Client/Crypto.cs
+++ b/src/BlockChyp/Client/Crypto.cs
@@ -36,7 +36,7 @@ namespace BlockChyp.Client
         public static Dictionary<string, string> GenerateAuthHeaders(ApiCredentials credentials)
         {
             var nonce = GenerateNonce(NonceSizeBytes);
-            var timestamp = GetTimestamp();
+            var timestamp = GetRfc3339Timestamp();
 
             var toSign = credentials.ApiKey + credentials.BearerToken + timestamp + nonce;
             byte[] key = FromHex(credentials.SigningKey);
@@ -76,8 +76,10 @@ namespace BlockChyp.Client
             }
         }
 
-        /// <summary>Returns the current timestamp in RFS 3339 format.</summary>
-        public static string GetTimestamp()
+        /// <summary>
+        /// Returns the current timestamp in RFC 3339 format.
+        /// </summary>
+        public static string GetRfc3339Timestamp()
         {
             return DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'");
         }

--- a/src/BlockChyp/Client/Crypto.cs
+++ b/src/BlockChyp/Client/Crypto.cs
@@ -29,15 +29,13 @@ namespace BlockChyp.Client
 
         private const int AesKeySizeBytes = 16;
 
-        private const int NonceSizeBytes = 32;
-
-        private static RNGCryptoServiceProvider _rand = new RNGCryptoServiceProvider();
+        public const int NonceSizeBytes = 32;
 
         /// <summary>Generates request headers for authorization to the BlockChyp gateway.</summary>
         /// <param name="credentials">API credentials used to generate request headers.</param>
         public static Dictionary<string, string> GenerateAuthHeaders(ApiCredentials credentials)
         {
-            var nonce = GenerateNonce();
+            var nonce = GenerateNonce(NonceSizeBytes);
             var timestamp = GetTimestamp();
 
             var toSign = credentials.ApiKey + credentials.BearerToken + timestamp + nonce;
@@ -59,13 +57,23 @@ namespace BlockChyp.Client
             };
         }
 
-        /// <summary>Generates a random nonce for use in requests.</summary>
-        public static string GenerateNonce()
+        /// <summary>
+        /// Generate a <paramref name="nonceLengthInBytes"/>-byte long random nonce using
+        /// <c>RNGCryptoServiceProvider</c>.
+        /// </summary>
+        /// <remarks>
+        /// Note that the resulting nonce will be represented as a hex <c>string</c> which will therefore have a
+        /// length of <c>2 * nonceLengthInBytes</c>.
+        /// </remarks>
+        /// <param name="nonceLengthInBytes">the desired length of the nonce in bytes.</param>
+        public static string GenerateNonce(int nonceLengthInBytes)
         {
-            byte[] nonceBytes = new byte[NonceSizeBytes];
-            _rand.GetBytes(nonceBytes);
-
-            return BitConverter.ToString(nonceBytes).Replace("-", string.Empty);
+            using (RandomNumberGenerator rng = new RNGCryptoServiceProvider())
+            {
+                byte[] nonceBytes = new byte[nonceLengthInBytes];
+                rng.GetBytes(nonceBytes);
+                return BitConverter.ToString(nonceBytes).Replace("-", string.Empty);
+            }
         }
 
         /// <summary>Returns the current timestamp in RFS 3339 format.</summary>

--- a/tests/BlockChypTest/BlockChypTest.csproj
+++ b/tests/BlockChypTest/BlockChypTest.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
 <ItemGroup>
+  <PackageReference Include="FsCheck" Version="2.14.0" />
+  <PackageReference Include="FsCheck.Xunit" Version="2.14.0" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   <PackageReference Include="xunit" Version="2.4.1" />
   <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/tests/BlockChypTest/Client/CryptoArbitrary.cs
+++ b/tests/BlockChypTest/Client/CryptoArbitrary.cs
@@ -1,0 +1,51 @@
+using BlockChyp.Client;
+using FsCheck;
+
+namespace BlockChypTest.Client
+{
+    public sealed class NonceLength
+    {
+        public int Get { get; }
+
+        public NonceLength(int len)
+        {
+            Get = len;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1}", this.GetType().Name, Get);
+        }
+    }
+
+    public sealed class Nonce
+    {
+        public string Get { get; }
+
+        public Nonce(string nonce)
+        {
+            Get = nonce;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1}", this.GetType().Name, Get);
+        }
+    }
+
+    public class CryptoArbitrary
+    {
+        public static Arbitrary<NonceLength> NonceLength() =>
+            Arb.Default.PositiveInt()
+                .Generator
+                .Where(len => len.Get >= 16)
+                .Select(len => new NonceLength(len.Get))
+                .ToArbitrary();
+
+        public static Arbitrary<Nonce> Nonce() =>
+            NonceLength()
+                .Generator
+                .Select(nonceLen => new Nonce(Crypto.GenerateNonce(nonceLen.Get)))
+                .ToArbitrary();
+    }
+}

--- a/tests/BlockChypTest/Client/CryptoTest.cs
+++ b/tests/BlockChypTest/Client/CryptoTest.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using BlockChyp;
 using BlockChyp.Client;
+using FsCheck;
+using FsCheck.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,6 +16,9 @@ namespace BlockChypTest.Client
         public CryptoTest(ITestOutputHelper output)
         {
             this.output = output;
+
+            // Register Arbitrary instances
+            Arb.Register<CryptoArbitrary>();
         }
 
         [Fact]
@@ -34,6 +40,27 @@ namespace BlockChypTest.Client
             Assert.NotNull(result["Nonce"]);
             Assert.NotNull(result["Timestamp"]);
             Assert.NotNull(result["Authorization"]);
+        }
+
+        /// <summary>
+        /// Property: A nonce, <c>GenerateNonce(len)</c>, should be of length, <c>len</c>
+        /// </summary>
+        [Property(MaxTest = 10000)]
+        public bool prop_NonceLength_Correct(NonceLength nonceLength)
+        {
+            int hexEncodedNonceLength = nonceLength.Get * 2;  // 2 hex chars == 1 byte
+            return Crypto.GenerateNonce(nonceLength.Get).Length == hexEncodedNonceLength;
+        }
+
+        /// <summary>
+        /// Property: A nonce, <c>GenerateNonce(len)</c>, should only contain base-16 characters.
+        /// i.e. The nonce should be a hexadecimal-encoded <c>string</c>.
+        /// </summary>
+        [Property(MaxTest = 10000)]
+        public bool prop_Nonce_IsHexEncoded(NonceLength nonceLength)
+        {
+            string nonce = Crypto.GenerateNonce(nonceLength.Get);
+            return Regex.IsMatch(nonce, @"\A\b[0-9a-fA-F]+\b\Z");
         }
     }
 }

--- a/tests/BlockChypTest/Client/CryptoTest.cs
+++ b/tests/BlockChypTest/Client/CryptoTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using BlockChyp;
 using BlockChyp.Client;
@@ -61,6 +62,15 @@ namespace BlockChypTest.Client
         {
             string nonce = Crypto.GenerateNonce(nonceLength.Get);
             return Regex.IsMatch(nonce, @"\A\b[0-9a-fA-F]+\b\Z");
+        }
+
+        /// <summary>
+        /// Property: <c>ba.SequenceEqual(FromHex(ToHex(ba)))</c>
+        /// </summary>
+        [Property(MaxTest = 10000)]
+        public bool prop_ToHexFromHex_RoundTrip(byte[] ba)
+        {
+            return ba.SequenceEqual(Crypto.FromHex(Crypto.ToHex(ba)));
         }
     }
 }

--- a/tests/BlockChypTest/Client/PaymentTest.cs
+++ b/tests/BlockChypTest/Client/PaymentTest.cs
@@ -205,7 +205,7 @@ namespace BlockChypTest.Client
                 Amount="55.55",
                 Test=true,
                 TerminalName=IntegrationTestConfiguration.Instance.Settings.DefaultTerminalName,
-                TransactionRef=Crypto.GenerateNonce(),
+                TransactionRef=Crypto.GenerateNonce(Crypto.NonceSizeBytes),
             };
 
             var chargeResponse = blockchyp.Charge(chargeRequest);
@@ -299,7 +299,7 @@ namespace BlockChypTest.Client
                 Amount="55.55",
                 Test=true,
                 TerminalName=IntegrationTestConfiguration.Instance.Settings.DefaultTerminalName,
-                TransactionRef=Crypto.GenerateNonce(),
+                TransactionRef=Crypto.GenerateNonce(Crypto.NonceSizeBytes),
             };
 
             var chargeResponse = blockchyp.Charge(chargeRequest);


### PR DESCRIPTION
Refactored:
- `Crypto.GenerateNonce`
- `Crypto.GetTimestamp`
- `Crypto.FromHex`

Added `FsCheck` to `BlockChypTest` and some accompanying property-based tests for:
- `Crypto.GenerateNonce`
- Round-trip test for `Crypto.ToHex` and `Crypto.FromHex`