### PR TITLE
Refactor CryptoTest_EncryptDecrypt as a property test

### DIFF
--- a/tests/BlockChypTest/Client/CryptoArbitrary.cs
+++ b/tests/BlockChypTest/Client/CryptoArbitrary.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using BlockChyp.Client;
 using FsCheck;
 
@@ -33,6 +34,25 @@ namespace BlockChypTest.Client
         }
     }
 
+    public sealed class AesKey
+    {
+        public byte[] Get { get; }
+
+        public AesKey(byte[] key)
+        {
+            Get = key;
+        }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "{0} {1}",
+                this.GetType().Name,
+                System.BitConverter.ToString(Get).Replace("-", string.Empty)
+            );
+        }
+    }
+
     public class CryptoArbitrary
     {
         public static Arbitrary<NonceLength> NonceLength() =>
@@ -47,5 +67,21 @@ namespace BlockChypTest.Client
                 .Generator
                 .Select(nonceLen => new Nonce(Crypto.GenerateNonce(nonceLen.Get)))
                 .ToArbitrary();
+
+        public static Arbitrary<AesKey> AesKey()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                const int BITS_PER_BYTE = 8;
+                int[] keySizes = new int[] {
+                    (aes.LegalKeySizes[0].MinSize / BITS_PER_BYTE),
+                    (aes.LegalKeySizes[0].MaxSize / BITS_PER_BYTE)
+                };
+                return (from len in Gen.Elements<int>(keySizes)
+                        from ba in Gen.ArrayOf<byte>(len, Arb.Generate<byte>())
+                        select new AesKey(ba)
+                        ).ToArbitrary();
+            }
+        }
     }
 }

--- a/tests/BlockChypTest/Client/CryptoTest.cs
+++ b/tests/BlockChypTest/Client/CryptoTest.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using BlockChyp.Client;
 using BlockChyp.Entities;
@@ -44,22 +43,15 @@ namespace BlockChypTest.Client
             Assert.NotNull(result["Authorization"]);
         }
 
-        [Fact]
-        public void CryptoTest_EncryptDecrypt()
+        /// <summary>
+        /// Test that the <c>Crypto.Encrypt</c> and <c>Crypto.Decrypt</c> methods round-trip.
+        /// </summary>
+        [Property(MaxTest = 10000)]
+        public bool prop_EncryptDecrypt_RoundTrip(NonNull<string> plaintext, AesKey aesKey)
         {
-            byte[] key;
-            using (Aes aes = Aes.Create())
-            {
-                key = aes.Key;
-            }
-
-            var plaintext = "some super secret sauce";
-
-            var encrypted = Crypto.Encrypt(plaintext, key);
-
-            var roundTrip = Crypto.Decrypt(encrypted, key);
-
-            Assert.Equal(plaintext, roundTrip);
+            string ciphertext = Crypto.Encrypt(plaintext.Get, aesKey.Get);
+            string roundTripPlaintext = Crypto.Decrypt(ciphertext, aesKey.Get);
+            return plaintext.Get == roundTripPlaintext;
         }
 
         /// <summary>


### PR DESCRIPTION
Seemed that `CryptoTest_EncryptDecrypt` might be better suited as a property-based test with generated inputs.