### PR TITLE
Separate terminal and gateway timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ try
         Console.WriteLine("Approved!");
     }
 }
-catch (WebException e) when (e.Status == WebExceptionStatus.Timeout)
+catch (TimeoutException)
 {
     AuthResponse reverseResponse = await blockchyp.ReverseAsync(request);
 

--- a/tests/BlockChypTest/Client/BlockChypClientTest.cs
+++ b/tests/BlockChypTest/Client/BlockChypClientTest.cs
@@ -12,7 +12,7 @@ namespace BlockChypTest.Client
         public async void BlockChypClientTest_Heartbeat()
         {
             var blockchyp = new BlockChypClient();
-            blockchyp.RequestTimeout = TimeSpan.FromSeconds(30);
+            blockchyp.GatewayRequestTimeout = TimeSpan.FromSeconds(30);
             var result = await blockchyp.HeartbeatAsync(false);
 
             Assert.True(result.Success);
@@ -38,7 +38,8 @@ namespace BlockChypTest.Client
         public async void BlockChypClientTest_Ping()
         {
             var blockchyp = IntegrationTestConfiguration.Instance.GetTestClient();
-            blockchyp.RequestTimeout = TimeSpan.FromSeconds(30);
+            blockchyp.GatewayRequestTimeout = TimeSpan.FromSeconds(30);
+            blockchyp.TerminalRequestTimeout = TimeSpan.FromSeconds(30);
 
             var terminalName = IntegrationTestConfiguration.Instance.Settings.DefaultTerminalName;
             var request = new PingRequest{TerminalName=terminalName};

--- a/tests/BlockChypTest/Client/PaymentTest.cs
+++ b/tests/BlockChypTest/Client/PaymentTest.cs
@@ -229,6 +229,52 @@ namespace BlockChypTest.Client
 
         [Trait("Category", "Integration")]
         [Fact]
+        public void PaymentTest_GatewayTimeout()
+        {
+            var blockchyp = IntegrationTestConfiguration.Instance.GetTestClient();
+
+            // Time out instantly
+            blockchyp.GatewayRequestTimeout = TimeSpan.FromSeconds(0);
+            blockchyp.TerminalRequestTimeout = TimeSpan.FromSeconds(30);
+            blockchyp.RouteCache.OfflineEnabled = false;
+
+            var chargeRequest = new AuthRequest{
+                Amount="55.55",
+                Test=true,
+                TerminalName=IntegrationTestConfiguration.Instance.Settings.DefaultTerminalName,
+                TransactionRef=Crypto.GenerateNonce(Crypto.NonceSizeBytes),
+            };
+
+            Exception ex = Assert.Throws<TimeoutException>(() => blockchyp.Charge(chargeRequest));
+
+            Assert.Equal("Gateway request timed out", ex.Message);
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact]
+        public void PaymentTest_TerminalTimeout()
+        {
+            var blockchyp = IntegrationTestConfiguration.Instance.GetTestClient();
+
+            // Time out instantly
+            blockchyp.GatewayRequestTimeout = TimeSpan.FromSeconds(30);
+            blockchyp.TerminalRequestTimeout = TimeSpan.FromSeconds(0);
+            blockchyp.RouteCache.OfflineEnabled = false;
+
+            var chargeRequest = new AuthRequest{
+                Amount="55.55",
+                Test=true,
+                TerminalName=IntegrationTestConfiguration.Instance.Settings.DefaultTerminalName,
+                TransactionRef=Crypto.GenerateNonce(Crypto.NonceSizeBytes),
+            };
+
+            Exception ex = Assert.Throws<TimeoutException>(() => blockchyp.Charge(chargeRequest));
+
+            Assert.Equal("Terminal request timed out", ex.Message);
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact]
         public async void PaymentTest_TaxExemptCharge()
         {
             var blockchyp = IntegrationTestConfiguration.Instance.GetTestClient();


### PR DESCRIPTION
Throw TimeoutException instead of TaskCanceledException.

Add test coverage for gateway and terminal timeouts.